### PR TITLE
Updates on entity harvester extension

### DIFF
--- a/europeana-entity-harvester/index.html
+++ b/europeana-entity-harvester/index.html
@@ -86,7 +86,7 @@
             organization: 'organization'
           };
           if (!type) return;
-          return names[type.toLowerCase()];
+          return names[type];
         }
 
         function sendMessage(text) {

--- a/europeana-entity-harvester/index.html
+++ b/europeana-entity-harvester/index.html
@@ -20,8 +20,6 @@
       // TODO: show a spinner when it's harvesting
 
       window.contentfulExtension.init(extension => {
-        let entityType;
-        
         extension.window.startAutoResizer();
 
         // find a value in one of the defined languages
@@ -70,7 +68,6 @@
           const pageMatch = entityUrl.match(new RegExp('^https?://[^/]+/entity(/(person|topic)/[0-9]+)'));
 
           if (pageMatch) {
-            entityType = pageMatch[2];
             return pageMatch[1].replace('person', 'agent/base').replace('topic', 'concept/base');
           }
 
@@ -79,6 +76,17 @@
 
         function entityTypeFromUri(entityUrl) {
             return entityUrl.match(/\/(agent|concept|place|organization)\//)[1];
+        }
+
+        function getEntityTypeHumanReadable(type) {
+          const names = {
+            agent: 'person',
+            concept: 'topic',
+            place: 'place',
+            organization: 'organization'
+          };
+          if (!type) return;
+          return names[type.toLowerCase()];
         }
 
         function sendMessage(text) {
@@ -174,7 +182,7 @@
           }
 
           if (extension.entry.fields.type) {
-            extension.entry.fields.type.setValue(entityType); // entity type
+            extension.entry.fields.type.setValue(getEntityTypeHumanReadable(entityTypeFromUri(response.id))); // entity type
           }
 
           // set name field from `prefLabel`

--- a/europeana-entity-harvester/index.html
+++ b/europeana-entity-harvester/index.html
@@ -66,9 +66,9 @@
         function entityIdFromUrl(entityUrl) {
           const uriMatch = entityUrl.match(new RegExp('^http://data.europeana.eu(/(agent|concept|place|organization)/(base/)?[0-9]+$)'));
           if (uriMatch) return uriMatch[1];
-          
+
           const pageMatch = entityUrl.match(new RegExp('^https?://[^/]+/entity(/(person|topic)/[0-9]+)'));
-          
+
           if (pageMatch) {
             entityType = pageMatch[2];
             return pageMatch[1].replace('person', 'agent/base').replace('topic', 'concept/base');
@@ -110,7 +110,7 @@
             showError(`Unable to harvest from URL: ${entityUrl}`);
             return;
           }
-          
+
           entityFromApi(entityId)
             .then(entity => {
               if (entity.valid) {
@@ -172,7 +172,7 @@
           if (extension.entry.fields.slug) {
             extension.entry.fields.slug.setValue(entitySlug(response)); // slug
           }
-          
+
           if (extension.entry.fields.type) {
             extension.entry.fields.type.setValue(entityType); // entity type
           }

--- a/europeana-entity-harvester/index.html
+++ b/europeana-entity-harvester/index.html
@@ -20,6 +20,8 @@
       // TODO: show a spinner when it's harvesting
 
       window.contentfulExtension.init(extension => {
+        let entityType;
+        
         extension.window.startAutoResizer();
 
         // find a value in one of the defined languages
@@ -64,9 +66,11 @@
         function entityIdFromUrl(entityUrl) {
           const uriMatch = entityUrl.match(new RegExp('^http://data.europeana.eu(/(agent|concept|place|organization)/(base/)?[0-9]+$)'));
           if (uriMatch) return uriMatch[1];
-
+          
           const pageMatch = entityUrl.match(new RegExp('^https?://[^/]+/entity(/(person|topic)/[0-9]+)'));
+          
           if (pageMatch) {
+            entityType = pageMatch[2];
             return pageMatch[1].replace('person', 'agent/base').replace('topic', 'concept/base');
           }
 
@@ -106,7 +110,7 @@
             showError(`Unable to harvest from URL: ${entityUrl}`);
             return;
           }
-
+          
           entityFromApi(entityId)
             .then(entity => {
               if (entity.valid) {
@@ -164,7 +168,14 @@
         function populateFields(response) {
           // set field values
           extension.entry.fields.identifier.setValue(response.id); // data.europeana.eu URI
-          extension.entry.fields.slug.setValue(entitySlug(response)); // slug
+          
+          if (extension.entry.fields.slug) {
+            extension.entry.fields.slug.setValue(entitySlug(response)); // slug
+          }
+          
+          if (extension.entry.fields.type) {
+            extension.entry.fields.type.setValue(entityType); // entity type
+          }
 
           // set name field from `prefLabel`
           if (extension.entry.fields.name) {


### PR DESCRIPTION
The extension now: 

- Does not throw an error when fields not exist for a content type
- Has an option to store the type (which is used to preview the entity)
